### PR TITLE
fix: 修复query参数以 & 结尾时, deepDecodeQuery 参数会为 null 的情况

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -456,7 +456,7 @@ export function deepDecodeQuery(
                 }
             }
         } else if (typeof it === 'object') {
-            const childQuery = deepDecodeQuery(it);
+            const childQuery = deepDecodeQuery(it || {});
             formatQuery[key] = childQuery
         } else {
             formatQuery[key] = it

--- a/src/public/query.ts
+++ b/src/public/query.ts
@@ -155,7 +155,7 @@ export function parseQuery(
                 }
             }
             if (typeof deepQuery === 'object') {
-                return deepDecodeQuery(deepQuery);
+                return deepDecodeQuery(deepQuery || {});
             }
         }
     }


### PR DESCRIPTION
query参数后面如果多了一个 & 的时候, query 对象中会包含 null

eg: https://www.demo.com?a=b&