### PR TITLE
add(test): query-toggle.spec.ts 单个普通参数匹配分组

### DIFF
--- a/test/query-toggle.spec.ts
+++ b/test/query-toggle.spec.ts
@@ -49,6 +49,17 @@ it('单个普通参数',()=>{
     expect(JSON.stringify(result)).toEqual(JSON.stringify(query));
 })
 
+it('单个普通参数2',()=>{
+    const query={
+        name:'wyb',
+        ages:22,
+        open:true
+    }
+    const result = deepDecodeQuery(query);
+
+    expect(JSON.stringify(result)).toEqual(JSON.stringify(query));
+})
+
 it('深度参数加混乱',()=>{
     const query={
         list:[


### PR DESCRIPTION
多个同类型测试用例分组匹配时异常，新增新分组排除此问题。

```js
it('单个普通参数2',()=>{
    const query={
        name:'wyb',
        ages:22,
        open:true
    }
    const result = deepDecodeQuery(query);

    expect(JSON.stringify(result)).toEqual(JSON.stringify(query));
})
```
